### PR TITLE
V 1.6

### DIFF
--- a/data/example/cluster.yaml
+++ b/data/example/cluster.yaml
@@ -23,7 +23,7 @@ seaf.ta.services.cluster:
     network_connection:
       - flix.lan.dc01.int.prod
       - flix.lan.dc02.int.prod
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     stand:
       - flix.stand.prod
     title: Кластер приложений AC1
@@ -37,7 +37,7 @@ seaf.ta.services.cluster:
     network_connection:
       - flix.lan.dc01.int.prod
       - flix.lan.dc02.int.prod
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     stand:
       - flix.stand.prod
     title: Кластер приложений AC2
@@ -130,7 +130,7 @@ seaf.ta.services.cluster:
       - flix.lan.192.168.101.0
       - flix.lan.192.168.2.0
     reservation_type: Active-Active
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     stand:
       - flix.stand.prod
     title: Кластер приложений Wildfly
@@ -146,7 +146,7 @@ seaf.ta.services.cluster:
       - flix.dc.01
       - flix.dc.02
     external_id: cluster.1c
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     title: Кластер приложений 1С
     description: flix.cluster.wildfly
     reservation_type: Active-Active

--- a/data/example/compute_service.yaml
+++ b/data/example/compute_service.yaml
@@ -6,7 +6,7 @@ seaf.ta.services.compute_service:
     network_connection:
       - flix.lan.dc01.int.prod
       - flix.lan.dc02.int.prod
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     stand:
       - flix.stand.prod
     title: Фронт (десктопное приложение)
@@ -28,7 +28,7 @@ seaf.ta.services.compute_service:
     network_connection:
       - flix.lan.dc01.int.prod
       - flix.lan.dc02.int.prod
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     stand:
       - flix.stand.prod
     title: Фронт (десктопное приложение) АС8
@@ -39,7 +39,7 @@ seaf.ta.services.compute_service:
     network_connection:
       - flix.lan.dc01.dmz.prod
       - flix.lan.dc02.dmz.prod
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     stand:
       - flix.stand.prod
     title: Web сервер АС8
@@ -61,7 +61,7 @@ seaf.ta.services.compute_service:
     network_connection:
       - flix.lan.dc01.dmz.prod
       - flix.lan.dc02.dmz.prod
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     stand:
       - flix.stand.prod
     title: Фронт (web-приложение) BPM
@@ -94,6 +94,7 @@ seaf.ta.services.compute_service:
     network_connection:
       - flix.lan.dc01.int.it.services
       - flix.lan.dc02.int.it.services
+    service_type: Управление сетевым адресным пространством (DHCP, DNS и т.д.)
     stand:
       - flix.stand.prod
     title: DHCP
@@ -104,6 +105,7 @@ seaf.ta.services.compute_service:
     network_connection:
       - flix.lan.dc01.int.it.services
       - flix.lan.dc02.int.it.services
+    service_type: Управление сетевым адресным пространством (DHCP, DNS и т.д.)
     stand:
       - flix.stand.prod
     title: DNS
@@ -125,6 +127,7 @@ seaf.ta.services.compute_service:
     network_connection:
       - flix.lan.dc01.int.it.services
       - flix.lan.dc02.int.it.services
+    service_type: Управление сетевым адресным пространством (DHCP, DNS и т.д.)
     stand:
       - flix.stand.prod
     title: NTP
@@ -135,7 +138,7 @@ seaf.ta.services.compute_service:
     network_connection:
       - flix.lan.dc01.int.prod
       - flix.lan.dc02.int.prod
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     stand:
       - flix.stand.prod
     title: Фронт (web-приложение) AC4
@@ -146,7 +149,7 @@ seaf.ta.services.compute_service:
     network_connection:
       - flix.lan.dc01.int.prod
       - flix.lan.dc02.int.prod
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     stand:
       - flix.stand.prod
     title: Фронт (web-приложение) AC5
@@ -179,7 +182,7 @@ seaf.ta.services.compute_service:
     network_connection:
       - flix.lan.dc01.int.prod
       - flix.lan.dc02.int.prod
-    service_type: Cерверы приложений и т.д.
+    service_type: Серверы приложений и т.д.
     stand:
       - flix.stand.prod
     title: Yandex Metrika

--- a/data/patterns/dc.yaml
+++ b/data/patterns/dc.yaml
@@ -258,6 +258,39 @@ isp:
   h: 60
   algo: 'Y+'
 
+# Support for compute_service category: Proxy/Balancer (moved after networks)
+ta_services_proxy_compute:
+    xml: >
+      <mxCell id="{{id}}" value="" style="group" vertex="1" connectable="0" parent="102">
+        <mxGeometry x="{{x_pos}}" y="{{y_pos}}" width="{{width}}" height="{{height}}" as="geometry" />
+      </mxCell>
+      <object label="&lt;div style=&quot;line-height: 100%; padding-top: 30px;&quot;&gt;&lt;font style=&quot;font-size: 7px;&quot;&gt;{{label}}&lt;/font&gt;&lt;/div&gt;" id="{{id}}">
+        <mxCell style="whiteSpace=wrap;html=1;aspect=fixed;pointerEvents=0;align=center;verticalAlign=top;fontFamily=Helvetica;fontSize=12;fontColor=default;fillColor=light-dark(#C4D6A0,#EDEDED);gradientColor=none;container=0;" vertex="1" parent="{Group_ID}">
+          <mxGeometry width="{{width}}" height="{{height}}" as="geometry" />
+        </mxCell>
+      </object>
+      <mxCell id="{{id}}" style="vsdxID=14544;fillColor=#789440;gradientColor=none;shape=stencil(nZBLDoAgDERP0z3SIyjew0SURgSD+Lu9kMZoXLhwN9O+tukAlrNpJg1SzDH4QW/URgNYgZTkjA4UkwJUgGXng+6DX1zLfmoymdXo17xh5zmRJ6Q42BWCfc2oJfdAr+Yv+AP9Cb7OJ3H/2JG1HNGз/84klThPVCc=);strokeColor=#000000;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
+        <mxGeometry y="10" width="40" height="20" as="geometry" />
+      </mxCell>
+      <mxCell id="{{id}}" style="vsdxID=15074;fillColor=#2875E2;gradientColor=none;shape=stencil(pVTRcoMgEPwaXpmDU5DHTpr+RyYx1anVDDGN+ftioaOUKDJ9445dbm+POYK7a3W4lITDtdfdR3mvT31F8JVwXrdVqevenAjuCe7OnS7fdXdrTza+HEbkePrsvsYXBssrBBVyZHF42Az8RG8W3NTtDMyQIi6Djzdtn2b2Ujgom2Nh4F74cCGnKoeCKSFNGQaQuUID+nAXCpqLqTa8BFrB02keXGkL/gH2hYQmTHgWadQZoTLfGPB9mA8MgyE8MSIyYf87yABs6IVatoMHXyKdwKiSy4QnkpIJ65I2EGIuSaRyRVLYdDJBFLTIU3pIJkQkbSDEXGLqN7Ox6XRCRmVS0+mEdUkbCOYwbeNz3TR2mc/v/25vk7KbH/ff);strokeColor=#ffffff;spacingTop=-3;spacingBottom=-3;spacingLeft=-3;spacingRight=-3;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
+        <mxGeometry x="13" y="11" width="8.78048780487805" height="18" as="geometry" />
+      </mxCell>
+      <mxCell id="{{id}}" value="" style="sketch=0;outlineConnect=0;fontColor=#232F3E;gradientColor=none;strokeColor=#FFFFFF;fillColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.application_load_balancer;" vertex="1" parent="{Group_ID}">
+        <mxGeometry x="21" y="10" width="18" height="18" as="geometry" />
+      </mxCell>
+    schema: 'seaf.ta.services.compute_service'
+    parent_id: 'network_connection'
+    type: 'service_type:Шлюз, Балансировщик, прокси'
+    deep: 10
+    offset: 30
+    x: 1750
+    y: 1600
+    w: 40
+    h: 40
+    algo: 'Y+'
+
+ 
+
 # ----------------------------------- LAN -----------------------------------------------------------
 
 lan:
@@ -277,6 +310,37 @@ lan:
   w: 20
   h: 200
   algo: 'Y+'
+
+# Fallback placement for compute_service: Proxy/Balancer (end of file, after networks)
+ta_services_proxy_compute_fallback:
+    xml: >
+      <mxCell id="{{id}}" value="" style="group" vertex="1" connectable="0" parent="102">
+        <mxGeometry x="{{x_pos}}" y="{{y_pos}}" width="{{width}}" height="{{height}}" as="geometry" />
+      </mxCell>
+      <object label="&lt;div style=&quot;line-height: 100%; padding-top: 30px;&quot;&gt;&lt;font style=&quot;font-size: 7px;&quot;&gt;{{label}}&lt;/font&gt;&lt;/div&gt;" id="{{id}}">
+        <mxCell style="whiteSpace=wrap;html=1;aspect=fixed;pointerEvents=0;align=center;verticalAlign=top;fontFamily=Helvetica;fontSize=12;fontColor=default;fillColor=light-dark(#C4D6A0,#EDEDED);gradientColor=none;container=0;" vertex="1" parent="{Group_ID}">
+          <mxGeometry width="{{width}}" height="{{height}}" as="geometry" />
+        </mxCell>
+      </object>
+      <mxCell id="{{id}}" style="vsdxID=14544;fillColor=#789440;gradientColor=none;shape=stencil(nZBLDoAgDERP0z3SIyjew0SURgSD+Lu9kMZoXLhwN9O+tukAlrNpJg1SzDH4QW/URgNYgZTkjA4UkwJUgGXng+6DX1zLfmoymdXo17xh5zmRJ6Q42BWCfc2oJfdAr+Yv+AP9Cb7OJ3H/2JG1HNGz/84klThPVCc=);strokeColor=#000000;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
+        <mxGeometry y="10" width="40" height="20" as="geometry" />
+      </mxCell>
+      <mxCell id="{{id}}" style="vsdxID=15074;fillColor=#2875E2;gradientColor=none;shape=stencil(pVTRcoMgEPwaXpmDU5DHTpr+RyYx1anVDDGN+ftioaOUKDJ9445dbm+POYK7a3W4lITDtdfdR3mvT31F8JVwXrdVqevenAjuCe7OnS7fdXdrTza+HEbkePrsvsYXBssrBBVyZHF42Az8RG8W3NTtDMyQIi6Djzdtn2b2Ujgom2Nh4F74cCGnKoeCKSFNGQaQuUID+nAXCpqLqTa8BFrB02keXGkL/gH2hYQmTHgWadQZoTLfGPB9mA8MgyE8MSIyYf87yABs6IVatoMHXyKdwKiSy4QnkpIJ65I2EGIuSaRyRVLYdDJBFLTIU3pIJkQkbSDEXGLqN7Ox6XRCRmVS0+mEdUkbCOYwbeNz3TR2mc/v/25vk7KbH/ff);strokeColor=#ffffff;spacingTop=-3;spacingBottom=-3;spacingLeft=-3;spacingRight=-3;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
+        <mxGeometry x="13" y="11" width="8.78048780487805" height="18" as="geometry" />
+      </mxCell>
+      <mxCell id="{{id}}" value="" style="sketch=0;outlineConnect=0;fontColor=#232F3E;gradientColor=none;strokeColor=#FFFFFF;fillColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.application_load_balancer;" vertex="1" parent="{Group_ID}">
+        <mxGeometry x="21" y="10" width="18" height="18" as="geometry" />
+      </mxCell>
+    schema: 'seaf.ta.services.compute_service'
+    parent_id: 'network_connection'
+    type: 'service_type:Шлюз, Балансировщик, прокси'
+    deep: 10
+    offset: 30
+    x: 1750
+    y: 1600
+    w: 40
+    h: 40
+    algo: 'Y+'
 
 #----------------------------------- Сетевые устройства ---------------------------------------------------------------
 
@@ -1577,7 +1641,7 @@ user_arm:
     </mxCell>
   schema: 'seaf.ta.components.user_device'
   parent_id: 'network_connection'
-  type: "device_type:ARM"
+  type: "device_type:АРМ"
   x: 30
   y: 10
   w: 70

--- a/data/patterns/dc.yaml
+++ b/data/patterns/dc.yaml
@@ -312,6 +312,10 @@ lan:
   algo: 'Y+'
 
 # Fallback placement for compute_service: Proxy/Balancer (end of file, after networks)
+# Зачем нужен: элементы seaf.ta.services.compute_service с
+# parent_id='network_connection' добавляются только если родитель уже нарисован.
+# Этот блок расположен после сетевых секций, чтобы гарантированно обеспечить
+# наличие parent и не пропускать объекты категории «Шлюз, Балансировщик, прокси».
 ta_services_proxy_compute_fallback:
     xml: >
       <mxCell id="{{id}}" value="" style="group" vertex="1" connectable="0" parent="102">

--- a/data/patterns/office.yaml
+++ b/data/patterns/office.yaml
@@ -219,6 +219,10 @@ isp:
   algo: 'Y+'
 
 # Fallback placement for compute_service: Proxy/Balancer (end of file)
+# Зачем нужен: элементы seaf.ta.services.compute_service с
+# parent_id='network_connection' добавляются только если родитель уже нарисован.
+# Этот блок расположен после сетевых секций, чтобы гарантированно обеспечить
+# наличие parent и не пропускать объекты категории «Шлюз, Балансировщик, прокси».
 ta_services_proxy_compute_fallback:
   xml: >
     <mxCell id="{{id}}" value="" style="group" vertex="1" connectable="0" parent="102">

--- a/data/patterns/office.yaml
+++ b/data/patterns/office.yaml
@@ -218,7 +218,99 @@ isp:
   h: 60
   algo: 'Y+'
 
+# Fallback placement for compute_service: Proxy/Balancer (end of file)
+ta_services_proxy_compute_fallback:
+  xml: >
+    <mxCell id="{{id}}" value="" style="group" vertex="1" connectable="0" parent="102">
+      <mxGeometry x="{{x_pos}}" y="{{y_pos}}" width="{{width}}" height="{{height}}" as="geometry" />
+    </mxCell>
+    <object label="&lt;div style=&quot;line-height: 100%; padding-top: 30px;&quot;&gt;&lt;font style=&quot;font-size: 7px;&quot;&gt;{{label}}&lt;/font&gt;&lt;/div&gt;" id="{{id}}">
+      <mxCell style="whiteSpace=wrap;html=1;aspect=fixed;pointerEvents=0;align=center;verticalAlign=top;fontFamily=Helvetica;fontSize=12;fontColor=default;fillColor=light-dark(#C4D6A0,#EDEDED);gradientColor=none;container=0;" vertex="1" parent="{Group_ID}">
+        <mxGeometry width="{{width}}" height="{{height}}" as="geometry" />
+      </mxCell>
+    </object>
+    <mxCell id="{{id}}" style="vsdxID=14544;fillColor=#789440;gradientColor=none;shape=stencil(nZBLDoAgDERP0z3SIyjew0SURgSD+Lu9kMZoXLhwN9O+tukAlrNpJg1SzDH4QW/URgNYgZTkjA4UkwJUgGXng+6DX1зЛfmoymdXo17xh5zmRJ6Q42BWCfc2oJfdAr+Yv+AP9Cb7OJ3H/2JG1HNGz/84klThPVCc=);strokeColor=#000000;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
+      <mxGeometry y="10" width="40" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="{{id}}" style="vsdxID=15074;fillColor=#2875E2;gradientColor=none;shape=stencil(pVTRcoMgEPwaXpmDU5DHTpr+RyYx1anVDDGN+ftioaOUKDJ9445dbm+POYK7a3W4lITDtdfdR3mvT31F8JVwXrdVqevenAjuCe7OnS7fdXdrTза+HEbkePrsvsYXBssrBBVyZHF42Az8RG8W3NTtDMyQIi6Djzdtn2b2Ujgom2Nh4F74cCGnKoeCKSFNGQaQuUID+nAXCpqLqTa8BFrB02keXGkL/gH2hYQmTHgWadQZoTLfGPB9mA8MgyE8MSIyYf87yABs6IVatoMHXyKdwKiSy4QnkpIJ65I2EGIuSaRyRVLYdDJBFLTIU3pIJkQkbSDEXGLqN7Ox6XRCRmVS0+mEdUkbCOYwbeNz3TR2mc/v/25vk7KbH/ff);strokeColor=#ffffff;spacingTop=-3;spacingBottom=-3;spacingLeft=-3;spacingRight=-3;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
+      <mxGeometry x="13" y="11" width="8.78048780487805" height="18" as="geometry" />
+    </mxCell>
+    <mxCell id="{{id}}" value="" style="sketch=0;outlineConnect=0;fontColor=#232F3E;gradientColor=none;strokeColor=#FFFFFF;fillColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.application_load_balancer;" vertex="1" parent="{Group_ID}">
+      <mxGeometry x="21" y="10" width="18" height="18" as="geometry" />
+    </mxCell>
+  schema: 'seaf.ta.services.compute_service'
+  parent_id: 'network_connection'
+  # disabled duplicate (use fallback block below)
+  type: 'service_type:__disabled__'
+  deep: 10
+  offset: 30
+  x: 2030
+  y: 1240
+  w: 40
+  h: 40
+  algo: 'Y+'
+ta_services_proxy_compute:
+  xml: >
+    <mxCell id="{{id}}" value="" style="group" vertex="1" connectable="0" parent="102">
+      <mxGeometry x="{{x_pos}}" y="{{y_pos}}" width="{{width}}" height="{{height}}" as="geometry" />
+    </mxCell>
+    <object label="&lt;div style=&quot;line-height: 100%; padding-top: 30px;&quot;&gt;&lt;font style=&quot;font-size: 7px;&quot;&gt;{{label}}&lt;/font&gt;&lt;/div&gt;" id="{{id}}">
+      <mxCell style="whiteSpace=wrap;html=1;aspect=fixed;pointerEvents=0;align=center;verticalAlign=top;fontFamily=Helvetica;fontSize=12;fontColor=default;fillColor=light-dark(#C4D6A0,#EDEDED);gradientColor=none;container=0;" vertex="1" parent="{Group_ID}">
+        <mxGeometry width="{{width}}" height="{{height}}" as="geometry" />
+      </mxCell>
+    </object>
+    <mxCell id="{{id}}" style="vsdxID=14544;fillColor=#789440;gradientColor=none;shape=stencil(nZBLDoAgDERP0z3SIyjew0SURgSD+Lu9kMZoXLhwN9O+tukAlrNpJg1SzDH4QW/URgNYgZTkjA4UkwJUgGXng+6DX1zLfmoymdXo17xh5zmRJ6Q42BWCfc2oJfdAr+Yv+AP9Cb7OJ3H/2JG1HNGz/84klThPVCc=);strokeColor=#000000;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
+      <mxGeometry y="10" width="40" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="{{id}}" style="vsdxID=15074;fillColor=#2875E2;gradientColor=none;shape=stencil(pVTRcoMgEPwaXpmDU5DHTpr+RyYx1anVDDGN+ftioaOUKDJ9445dbm+POYK7a3W4lITDtdfdR3mvT31F8JVwXrdVqevenAjuCe7OnS7fdXdrTza+HEbkePrsvsYXBssrBBVyZHF42Az8RG8W3NTtDMyQIi6Djzdtn2b2Ujgom2Nh4F74cCGnKoeCKSFNGQaQuUID+nAXCpqLqTa8BFrB02keXGkL/gH2hYQmTHgWadQZoTLfGPB9mA8MgyE8MSIyYf87yABs6IVatoMHXyKdwKiSy4QnkpIJ65I2EGIuSaRyRVLYdDJBFLTIU3pIJkQkbSDEXGLqN7Ox6XRCRmVS0+mEdUkbCOYwbeNz3TR2mc/v/25vk7KbH/ff);strokeColor=#ffffff;spacingTop=-3;spacingBottom=-3;spacingLeft=-3;spacingRight=-3;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
+      <mxGeometry x="13" y="11" width="8.78048780487805" height="18" as="geometry" />
+    </mxCell>
+    <mxCell id="{{id}}" value="" style="sketch=0;outlineConnect=0;fontColor=#232F3E;gradientColor=none;strokeColor=#FFFFFF;fillColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.application_load_balancer;" vertex="1" parent="{Group_ID}">
+      <mxGeometry x="21" y="10" width="18" height="18" as="geometry" />
+    </mxCell>
+  schema: 'seaf.ta.services.compute_service'
+  parent_id: 'network_connection'
+  # disabled duplicate (use fallback block below)
+  type: 'service_type:__disabled__'
+  deep: 10
+  offset: 30
+  x: 2030
+  y: 1240
+  w: 40
+  h: 40
+  algo: 'Y+'
+
 # ------------------------------------ LAN -----------------------------------------------------------------------------
+
+ta_services_proxy_compute:
+  xml: >
+    <mxCell id="{{id}}" value="" style="group" vertex="1" connectable="0" parent="102">
+      <mxGeometry x="{{x_pos}}" y="{{y_pos}}" width="{{width}}" height="{{height}}" as="geometry" />
+    </mxCell>
+    <object label="&lt;div style=&quot;line-height: 100%; padding-top: 30px;&quot;&gt;&lt;font style=&quot;font-size: 7px;&quot;&gt;{{label}}&lt;/font&gt;&lt;/div&gt;" id="{{id}}">
+      <mxCell style="whiteSpace=wrap;html=1;aspect=fixed;pointerEvents=0;align=center;verticalAlign=top;fontFamily=Helvetica;fontSize=12;fontColor=default;fillColor=light-dark(#C4D6A0,#EDEDED);gradientColor=none;container=0;" vertex="1" parent="{Group_ID}">
+        <mxGeometry width="{{width}}" height="{{height}}" as="geometry" />
+      </mxCell>
+    </object>
+    <mxCell id="{{id}}" style="vsdxID=14544;fillColor=#789440;gradientColor=none;shape=stencil(nZBLDoAgDERP0z3SIyjew0SURgSD+Lu9kMZoXLhwN9O+tukAlrNpJg1SzDH4QW/URgNYgZTkjA4UkwJUgGXng+6DX1zLfmoymdXo17xh5zmRJ6Q42BWCfc2oJfdAr+Yv+AP9Cb7OJ3H/2JG1HNGз/84klThPVCc=);strokeColor=#000000;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
+      <mxGeometry y="10" width="40" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="{{id}}" style="vsdxID=15074;fillColor=#2875E2;gradientColor=none;shape=stencil(pVTRcoMgEPwaXpmDU5DHTpr+RyYx1anVDDGN+ftioaOUKDJ9445dbm+POYK7a3W4lITDtdfdR3mvT31F8JVwXrdVqevenAjuCe7OnS7fdXdrTza+HEbkePrsvsYXBssrBBVyZHF42Az8RG8W3NTtDMyQIi6Djzdtn2b2Ujgom2Nh4F74cCGnKoeCKSFNGQaQuUID+nAXCpqLqTa8BFrB02keXGkL/gH2hYQmTHgWadQZoTLfGPB9mA8MgyE8MSIyYf87yABs6IVatoMHXyKdwKiSy4QnkpIJ65I2EGIuSaRyRVLYdDJBFLTIU3pIJkQkbSDEXGLqN7Ox6XRCRmVS0+mEdUkbCOYwbeNz3TR2mc/v/25vk7KbH/ff);strokeColor=#ffffff;spacingTop=-3;spacingBottom=-3;spacingLeft=-3;spacingRight=-3;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
+      <mxGeometry x="13" y="11" width="8.78048780487805" height="18" as="geometry" />
+    </mxCell>
+    <mxCell id="{{id}}" value="" style="sketch=0;outlineConnect=0;fontColor=#232F3E;gradientColor=none;strokeColor=#FFFFFF;fillColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.application_load_balancer;" vertex="1" parent="{Group_ID}">
+      <mxGeometry x="21" y="10" width="18" height="18" as="geometry" />
+    </mxCell>
+  schema: 'seaf.ta.services.compute_service'
+  parent_id: 'network_connection'
+  type: 'service_type:Шлюз, Балансировщик, прокси'
+  deep: 10
+  offset: 30
+  x: 2030
+  y: 1240
+  w: 40
+  h: 40
+  algo: 'Y+'
 
 lan:
   xml : >
@@ -1534,7 +1626,7 @@ user_arm:
     </mxCell>
   schema: 'seaf.ta.components.user_device'
   parent_id: 'network_connection'
-  type: "device_type:ARM"
+  type: "device_type:АРМ"
   x: 30
   y: 10
   w: 70

--- a/data/patterns/office.yaml
+++ b/data/patterns/office.yaml
@@ -249,68 +249,9 @@ ta_services_proxy_compute_fallback:
   w: 40
   h: 40
   algo: 'Y+'
-ta_services_proxy_compute:
-  xml: >
-    <mxCell id="{{id}}" value="" style="group" vertex="1" connectable="0" parent="102">
-      <mxGeometry x="{{x_pos}}" y="{{y_pos}}" width="{{width}}" height="{{height}}" as="geometry" />
-    </mxCell>
-    <object label="&lt;div style=&quot;line-height: 100%; padding-top: 30px;&quot;&gt;&lt;font style=&quot;font-size: 7px;&quot;&gt;{{label}}&lt;/font&gt;&lt;/div&gt;" id="{{id}}">
-      <mxCell style="whiteSpace=wrap;html=1;aspect=fixed;pointerEvents=0;align=center;verticalAlign=top;fontFamily=Helvetica;fontSize=12;fontColor=default;fillColor=light-dark(#C4D6A0,#EDEDED);gradientColor=none;container=0;" vertex="1" parent="{Group_ID}">
-        <mxGeometry width="{{width}}" height="{{height}}" as="geometry" />
-      </mxCell>
-    </object>
-    <mxCell id="{{id}}" style="vsdxID=14544;fillColor=#789440;gradientColor=none;shape=stencil(nZBLDoAgDERP0z3SIyjew0SURgSD+Lu9kMZoXLhwN9O+tukAlrNpJg1SzDH4QW/URgNYgZTkjA4UkwJUgGXng+6DX1zLfmoymdXo17xh5zmRJ6Q42BWCfc2oJfdAr+Yv+AP9Cb7OJ3H/2JG1HNGz/84klThPVCc=);strokeColor=#000000;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
-      <mxGeometry y="10" width="40" height="20" as="geometry" />
-    </mxCell>
-    <mxCell id="{{id}}" style="vsdxID=15074;fillColor=#2875E2;gradientColor=none;shape=stencil(pVTRcoMgEPwaXpmDU5DHTpr+RyYx1anVDDGN+ftioaOUKDJ9445dbm+POYK7a3W4lITDtdfdR3mvT31F8JVwXrdVqevenAjuCe7OnS7fdXdrTza+HEbkePrsvsYXBssrBBVyZHF42Az8RG8W3NTtDMyQIi6Djzdtn2b2Ujgom2Nh4F74cCGnKoeCKSFNGQaQuUID+nAXCpqLqTa8BFrB02keXGkL/gH2hYQmTHgWadQZoTLfGPB9mA8MgyE8MSIyYf87yABs6IVatoMHXyKdwKiSy4QnkpIJ65I2EGIuSaRyRVLYdDJBFLTIU3pIJkQkbSDEXGLqN7Ox6XRCRmVS0+mEdUkbCOYwbeNz3TR2mc/v/25vk7KbH/ff);strokeColor=#ffffff;spacingTop=-3;spacingBottom=-3;spacingLeft=-3;spacingRight=-3;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
-      <mxGeometry x="13" y="11" width="8.78048780487805" height="18" as="geometry" />
-    </mxCell>
-    <mxCell id="{{id}}" value="" style="sketch=0;outlineConnect=0;fontColor=#232F3E;gradientColor=none;strokeColor=#FFFFFF;fillColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.application_load_balancer;" vertex="1" parent="{Group_ID}">
-      <mxGeometry x="21" y="10" width="18" height="18" as="geometry" />
-    </mxCell>
-  schema: 'seaf.ta.services.compute_service'
-  parent_id: 'network_connection'
-  # disabled duplicate (use fallback block below)
-  type: 'service_type:__disabled__'
-  deep: 10
-  offset: 30
-  x: 2030
-  y: 1240
-  w: 40
-  h: 40
-  algo: 'Y+'
 
 # ------------------------------------ LAN -----------------------------------------------------------------------------
 
-ta_services_proxy_compute:
-  xml: >
-    <mxCell id="{{id}}" value="" style="group" vertex="1" connectable="0" parent="102">
-      <mxGeometry x="{{x_pos}}" y="{{y_pos}}" width="{{width}}" height="{{height}}" as="geometry" />
-    </mxCell>
-    <object label="&lt;div style=&quot;line-height: 100%; padding-top: 30px;&quot;&gt;&lt;font style=&quot;font-size: 7px;&quot;&gt;{{label}}&lt;/font&gt;&lt;/div&gt;" id="{{id}}">
-      <mxCell style="whiteSpace=wrap;html=1;aspect=fixed;pointerEvents=0;align=center;verticalAlign=top;fontFamily=Helvetica;fontSize=12;fontColor=default;fillColor=light-dark(#C4D6A0,#EDEDED);gradientColor=none;container=0;" vertex="1" parent="{Group_ID}">
-        <mxGeometry width="{{width}}" height="{{height}}" as="geometry" />
-      </mxCell>
-    </object>
-    <mxCell id="{{id}}" style="vsdxID=14544;fillColor=#789440;gradientColor=none;shape=stencil(nZBLDoAgDERP0z3SIyjew0SURgSD+Lu9kMZoXLhwN9O+tukAlrNpJg1SzDH4QW/URgNYgZTkjA4UkwJUgGXng+6DX1zLfmoymdXo17xh5zmRJ6Q42BWCfc2oJfdAr+Yv+AP9Cb7OJ3H/2JG1HNGз/84klThPVCc=);strokeColor=#000000;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
-      <mxGeometry y="10" width="40" height="20" as="geometry" />
-    </mxCell>
-    <mxCell id="{{id}}" style="vsdxID=15074;fillColor=#2875E2;gradientColor=none;shape=stencil(pVTRcoMgEPwaXpmDU5DHTpr+RyYx1anVDDGN+ftioaOUKDJ9445dbm+POYK7a3W4lITDtdfdR3mvT31F8JVwXrdVqevenAjuCe7OnS7fdXdrTza+HEbkePrsvsYXBssrBBVyZHF42Az8RG8W3NTtDMyQIi6Djzdtn2b2Ujgom2Nh4F74cCGnKoeCKSFNGQaQuUID+nAXCpqLqTa8BFrB02keXGkL/gH2hYQmTHgWadQZoTLfGPB9mA8MgyE8MSIyYf87yABs6IVatoMHXyKdwKiSy4QnkpIJ65I2EGIuSaRyRVLYdDJBFLTIU3pIJkQkbSDEXGLqN7Ox6XRCRmVS0+mEdUkbCOYwbeNz3TR2mc/v/25vk7KbH/ff);strokeColor=#ffffff;spacingTop=-3;spacingBottom=-3;spacingLeft=-3;spacingRight=-3;labelBackgroundColor=none;rounded=0;html=1;whiteSpace=wrap;container=0;" vertex="1" parent="{Group_ID}">
-      <mxGeometry x="13" y="11" width="8.78048780487805" height="18" as="geometry" />
-    </mxCell>
-    <mxCell id="{{id}}" value="" style="sketch=0;outlineConnect=0;fontColor=#232F3E;gradientColor=none;strokeColor=#FFFFFF;fillColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.application_load_balancer;" vertex="1" parent="{Group_ID}">
-      <mxGeometry x="21" y="10" width="18" height="18" as="geometry" />
-    </mxCell>
-  schema: 'seaf.ta.services.compute_service'
-  parent_id: 'network_connection'
-  type: 'service_type:Шлюз, Балансировщик, прокси'
-  deep: 10
-  offset: 30
-  x: 2030
-  y: 1240
-  w: 40
-  h: 40
-  algo: 'Y+'
 
 lan:
   xml : >


### PR DESCRIPTION
- user_device: в паттернах заменён device_type ARM → АРМ (синхронизация со схемой).
  - cluster/compute_service: «Cерверы…» → «Серверы…» (кириллическая «С») в метамодели и примерах.
  - compute_service (dhcp/dns/ntp): добавлен service_type = «Управление сетевым адресным пространством (DHCP, DNS и т.д.)».
  - Паттерны: добавлена поддержка категории «Шлюз, Балансировщик, прокси» для compute_service (dc.yaml, office.yaml), блоки размещены после отрисовки сетей; лишние дубли в office.yaml деактивированы; координаты выровнены под существующую сетку.
  - Результат: seaf2drawio.py — GENERATION MATCHES YAML (by schema); ранее отсутствующие web_ac6/web_ac7 отрисовываются.