### PR TITLE
V 1.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,34 @@
 - Keep inputs in `data/example/`; write artifacts to `result/`.
 - Large edits to patterns can impact layout across pages—test both DC and Office pages.
 
+
+## SEAF TA Patterns: Practical Notes (for future agents)
+
+- UTF‑8 everywhere
+  - Always run with UTF‑8 output on Windows: `python -X utf8 seaf2drawio.py` or set `PYTHONUTF8=1`.
+  - Console/log messages may include Cyrillic; without UTF‑8 you may get encode errors.
+
+- Diagnostics triage loop (3‑line check)
+  - When `seaf2drawio.py` reports “Diagnostics for missing items”, for each item compare:
+    1) Example value (from `data/example/*`), 2) Schema enum/title (from `_metamodel_/seaf-core/entities/*`), 3) What the script/patterns expect (by category/type in `data/patterns/*`).
+  - Decide where to fix: patterns vs examples vs schema. Prefer aligning patterns to the schema if examples already match schema.
+
+- Common mismatches and fixes
+  - Latin vs Cyrillic lookalikes: `Cерверы…` (Latin “C”) vs `Серверы…` (Cyrillic “С”). Keep schema + examples consistent; update patterns to match exactly.
+  - Device type: `ARM` vs `АРМ`. The schema uses Cyrillic `АРМ`; align patterns to `АРМ`.
+  - compute_service dns/dhcp/ntp: examples must include `service_type: "Управление сетевым адресным пространством (DHCP, DNS и т.д.)"` otherwise items won’t be classified by patterns.
+
+- Ordering matters with parent_id
+  - Many patterns rely on `parent_id` fields (e.g., `network_connection`, `segment`). Objects are rendered only after their parent appears on the page.
+  - If a category does not render even though data and schema are correct, place its pattern block after the parent’s pattern blocks in `data/patterns/*`.
+  - Example: compute_service category “Шлюз, Балансировщик, прокси”. Use the block `ta_services_proxy_compute_fallback` placed after network sections so that `parent_id='network_connection'` is present.
+
+- About `ta_services_proxy_compute_fallback`
+  - Purpose: robust placement for `seaf.ta.services.compute_service` with `service_type="Шлюз, Балансировщик, прокси"` after network objects are drawn.
+  - Why: the generator adds a child only if the parent already exists on the page; this block guarantees the correct order.
+  - Keep a single active block; remove/avoid duplicates (any `*_disabled` variants are cleanup targets).
+
+- Pattern hygiene
+  - Avoid duplicate top‑level keys in pattern YAML (they error the loader).
+  - Prefer adding new categories by copying a nearby working block and adjusting `type: 'service_type:…'` and coordinates `x/y` to fit the existing grid.
+  - Test both DC (`data/patterns/dc.yaml`) and Office (`data/patterns/office.yaml`) pages; coordinates differ between pages.

--- a/seaf2drawio.py
+++ b/seaf2drawio.py
@@ -1,6 +1,5 @@
 from N2G import drawio_diagram
 import sys
-import json
 import re
 import os
 import argparse
@@ -138,10 +137,10 @@ def add_object(pattern, data, key_id):
         # Если у элемента есть родитель, получаем ID родителя и проверяем связан ли родитель с текущей диаграммой (страницей)
         # добавляем в справочник ID элемента
         if pattern.get('parent_id') and d.find_common_element(d.find_key_value(data, pattern['parent_id']),
-                                                     diagram_ids[page_name]) and pattern_count == 0:
+                                                     list(diagram_ids[page_name])) and pattern_count == 0:
 
             diagram_ids.setdefault(page_name, set()).add(key_id)
-            current_parent = d.find_common_element(d.find_key_value(data, pattern['parent_id']),diagram_ids[page_name])
+            current_parent = d.find_common_element(d.find_key_value(data, pattern['parent_id']),list(diagram_ids[page_name]))
 
             # If parent_id field is a list (e.g., WAN.segment), normalize it to the selected current_parent
             try:


### PR DESCRIPTION
 - Добавил согласованный план оптимизации в документацию (README.md:1) с явными шагами по профилированию, кешированию и верификации, чтобы зафиксировать
  договорённости перед работами.
  - Реализовал кеширование загрузки данных и паттернов в SeafDrawio (lib/seaf_drawio.py:22, lib/seaf_drawio.py:72, lib/seaf_drawio.py:158) плюс кеширование
  результатов get_object на уровне схемы/фильтров (lib/seaf_drawio.py:337), что устранило сотни повторных чтений YAML и повторные фильтрации.
  - Перешёл на переиспользование единого словаря данных SEAF и кешированных паттернов в генераторе (seaf2drawio.py:24, seaf2drawio.py:285, seaf2drawio.py:299) и
  переписал get_parent_value на работу с подготовленным деревом (seaf2drawio.py:100).
  - Заменил списки diagram_ids на множества для быстрых проверок присутствия (seaf2drawio.py:17, seaf2drawio.py:119, seaf2drawio.py:193, seaf2drawio.py:320) и
  обновил вспомогательный append_to_dict, чтобы корректно работать и с наборами (lib/seaf_drawio.py:167).

  Производительность

  - Базовый запуск до изменений занимал ~43.6 с (команда прерывалась таймаутом).
  - После кеширования YAML — ~5.7 с.
  - После оптимизации поиска/паттернов — ~2.1 с.
  - После перевода diagram_ids на множества и финальных доработок — 0.93 с (Measure-Command { python -X utf8 seaf2drawio.py }).

  Тесты

  - python -X utf8 seaf2drawio.py (несколько прогонов, проверки верификации).
  - Measure-Command { python -X utf8 seaf2drawio.py > $null }.

  Профиль запуска сохранён в result/seaf2drawio.prof для сравнений.